### PR TITLE
Parametrize CKAN DB locale settings

### DIFF
--- a/roles/ckan/defaults/main.yml
+++ b/roles/ckan/defaults/main.yml
@@ -11,6 +11,11 @@ openssl_certs_dir: '/etc/pki/tls/certs'
 openssl_key_signed: localhost.key
 openssl_crt_signed: localhost.crt
 
+# CKAN Database settings
+ckan_db_encoding: UTF-8
+ckan_db_lc_collate: en_US.utf8
+ckan_db_lc_ctype: en_US.utf8
+
 # CKAN extension verions
 ckanext_harvest_version: 7dd82a0e01ba85b7f2f4cc02b66dd4948ed7093e
 ckanext_oaipmh_version: '{{ ilab_catalog_version }}'

--- a/roles/ckan/tasks/main.yml
+++ b/roles/ckan/tasks/main.yml
@@ -56,9 +56,9 @@
   become: yes
   postgresql_db:
     name: "ckan_default"
-    encoding: UTF-8
-    lc_collate: en_US.utf8
-    lc_ctype: en_US.utf8
+    encoding: "{{ ckan_db_encoding }}"
+    lc_collate: "{{ ckan_db_lc_collate }}"
+    lc_ctype: "{{ ckan_db_lc_ctype }}"
     template: template0
 
 


### PR DESCRIPTION
Needed for test environments that have been deployed with slightly
different Postgres locale settings.